### PR TITLE
Setting up RegisterFragment class

### DIFF
--- a/app/src/androidTest/java/com/example/jacocoagptestapp/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/jacocoagptestapp/ExampleInstrumentedTest.kt
@@ -24,9 +24,9 @@ class ExampleInstrumentedTest {
 
     @Test
     fun testJacocoCoverage() {
-        val testClass = TestClass()
+        val registerFragment = RegisterFragment()
 
-        val result = testClass.doSomething()
+        val result = registerFragment.doSomething()
 
         assertEquals(42, result)
     }

--- a/app/src/main/java/com/example/jacocoagptestapp/RegisterFragment.kt
+++ b/app/src/main/java/com/example/jacocoagptestapp/RegisterFragment.kt
@@ -1,6 +1,6 @@
 package com.example.jacocoagptestapp
 
-class TestClass {
+class RegisterFragment {
     fun doSomething(): Int {
         return 42
     }

--- a/app/src/test/java/com/example/jacocoagptestapp/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/jacocoagptestapp/ExampleUnitTest.kt
@@ -17,9 +17,9 @@ class ExampleUnitTest {
 
     @Test
     fun `jacoco test coverage`() {
-        val testClass = TestClass()
+        val registerFragment = RegisterFragment()
 
-        val result = testClass.doSomethingElse()
+        val result = registerFragment.doSomethingElse()
 
         assertEquals(1337, result)
     }


### PR DESCRIPTION
Renaming `TestClass` -> `RegisterFragment` to setup situation for new issue.

Run `jacocoTestReport` task and you'll see all coverage as expected.