### PR TITLE
Setting up SignInFragment class

### DIFF
--- a/app/src/androidTest/java/com/example/jacocoagptestapp/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/example/jacocoagptestapp/ExampleInstrumentedTest.kt
@@ -24,9 +24,9 @@ class ExampleInstrumentedTest {
 
     @Test
     fun testJacocoCoverage() {
-        val registerFragment = RegisterFragment()
+        val signInFragment = SignInFragment()
 
-        val result = registerFragment.doSomething()
+        val result = signInFragment.doSomething()
 
         assertEquals(42, result)
     }

--- a/app/src/main/java/com/example/jacocoagptestapp/SignInFragment.kt
+++ b/app/src/main/java/com/example/jacocoagptestapp/SignInFragment.kt
@@ -1,6 +1,6 @@
 package com.example.jacocoagptestapp
 
-class RegisterFragment {
+class SignInFragment {
     fun doSomething(): Int {
         return 42
     }

--- a/app/src/test/java/com/example/jacocoagptestapp/ExampleUnitTest.kt
+++ b/app/src/test/java/com/example/jacocoagptestapp/ExampleUnitTest.kt
@@ -17,9 +17,9 @@ class ExampleUnitTest {
 
     @Test
     fun `jacoco test coverage`() {
-        val registerFragment = RegisterFragment()
+        val signInFragment = SignInFragment()
 
-        val result = registerFragment.doSomethingElse()
+        val result = signInFragment.doSomethingElse()
 
         assertEquals(1337, result)
     }


### PR DESCRIPTION
Renaming `RegisterFragment` -> `SignInFragment` to demonstrate a working situation/isolate the bug info.

Run `jacocoTestReport` task and you'll see all coverage as expected.  

This would seem to indicate AGP 8.8.0 does not work properly with classes named `RegisterFragment` for some reason.